### PR TITLE
corrected datacustodian selection to display datacustodianId instead of thirdPartyApplicationName

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/RetailCustomer/DataCustodianList/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/RetailCustomer/DataCustodianList/index.jsp
@@ -54,7 +54,7 @@
                             <td>
                                 <label>
                                     <input type="radio" name="Data_custodian" value="${applicationInformation.dataCustodianId}" data-data-custodian-url="${applicationInformation.thirdPartyScopeSelectionScreenURI}" class="data-custodian" />
-                                    <c:out value="${applicationInformation.thirdPartyApplicationName}"/>
+                                    <c:out value="${applicationInformation.dataCustodianId}"/>
                                 </label>
                             </td>
                         </tr>


### PR DESCRIPTION
The data custodian list was displaying the third party application name field instead of the data custodian id in the table.
